### PR TITLE
ci: Fixes bug in release description.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,6 +105,6 @@ jobs:
             IPFS gateways:
             - https://${{ steps.convert-cidv0.outputs.cidv1 }}.ipfs.dweb.link/
             - https://${{ steps.convert-cidv0.outputs.cidv1 }}.ipfs.cf-ipfs.com/
-            - [ipfs://${{ steps.upload.outputs.hash }}/](ipfs://${{ steps.pinata.outputs.hash }}/)
+            - [ipfs://${{ steps.convert-cidv0.outputs.cidv1 }}/](ipfs://${{ steps.convert-cidv0.outputs.cidv1 }}/)
 
             ${{ needs.tag.outputs.changelog }}


### PR DESCRIPTION
ipfs://<CIDv1> was empty.  I'm not sure what caused this, but switching to use the same thing as the other two links should fix it.